### PR TITLE
issue(4): fixed json naming policy

### DIFF
--- a/ClassLibraries/Macross.Json.Extensions/Code/JsonStringEnumMemberConverter{T}.cs
+++ b/ClassLibraries/Macross.Json.Extensions/Code/JsonStringEnumMemberConverter{T}.cs
@@ -29,6 +29,8 @@ namespace System.Text.Json.Serialization
 			}
 		}
 
+		private const BindingFlags EnumBindings = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static;
+
 		private readonly bool _AllowIntegerValues;
 		private readonly Type? _UnderlyingType;
 		private readonly Type _EnumType;
@@ -62,18 +64,9 @@ namespace System.Text.Json.Serialization
 				ulong rawValue = GetEnumValue(enumValue);
 
 				string name = builtInNames[i];
-
-				string transformedName;
-				if (namingPolicy == null)
-				{
-					FieldInfo field = _EnumType.GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)!;
-					EnumMemberAttribute enumMemberAttribute = field.GetCustomAttribute<EnumMemberAttribute>(true);
-					transformedName = enumMemberAttribute?.Value ?? name;
-				}
-				else
-				{
-					transformedName = namingPolicy.ConvertName(name) ?? name;
-				}
+				FieldInfo field = _EnumType.GetField(name, EnumBindings)!;
+				EnumMemberAttribute enumMemberAttribute = field.GetCustomAttribute<EnumMemberAttribute>(true);
+				string transformedName = enumMemberAttribute?.Value ?? namingPolicy?.ConvertName(name) ?? name;
 
 				_RawToTransformed[rawValue] = new EnumInfo(transformedName, enumValue, rawValue);
 				_TransformedToRaw[transformedName] = new EnumInfo(name, enumValue, rawValue);

--- a/ClassLibraries/Macross.Json.Extensions/Test/JsonStringEnumMemberConverterTests.cs
+++ b/ClassLibraries/Macross.Json.Extensions/Test/JsonStringEnumMemberConverterTests.cs
@@ -56,6 +56,34 @@ namespace Macross.Json.Extensions.Tests
 			Assert.AreEqual(DayOfWeek.Friday, Value);
 		}
 
+		[TestMethod]
+		public void EnumMemberSerializationOptionsTest()
+		{
+			JsonSerializerOptions options = new JsonSerializerOptions
+			{
+				Converters = { new JsonStringEnumMemberConverter(JsonNamingPolicy.CamelCase) }
+			};
+			string json = JsonSerializer.Serialize(TestValues.First, options);
+			Assert.AreEqual(@"""first""", json);
+
+			json = JsonSerializer.Serialize(TestValues.Second, options);
+			Assert.AreEqual(@"""_second""", json);
+		}
+
+		[TestMethod]
+		public void EnumMemberDeserializationOptionsTest()
+		{
+			JsonSerializerOptions options = new JsonSerializerOptions
+			{
+				Converters = { new JsonStringEnumMemberConverter(JsonNamingPolicy.CamelCase) }
+			};
+			TestValues Value = JsonSerializer.Deserialize<TestValues>(@"""first""", options);
+			Assert.AreEqual(TestValues.First, Value);
+
+			Value = JsonSerializer.Deserialize<TestValues>(@"""_second""", options);
+			Assert.AreEqual(TestValues.Second, Value);
+		}
+
 		[JsonConverter(typeof(JsonStringEnumMemberConverter))]
 		[Flags]
 		public enum FlagDefinitions
@@ -73,6 +101,14 @@ namespace Macross.Json.Extensions.Tests
 			Three = 0x04,
 			[EnumMember(Value = "four value")]
 			Four = 0x08,
+		}
+
+		public enum TestValues
+		{
+			First,
+
+			[EnumMember(Value = "_second")]
+			Second,
 		}
 	}
 }


### PR DESCRIPTION
With this PR one is able to use JsonNamingPolicy with JsonStringEnumMemberConverter.

Resolves #4 