### PR TITLE
Improve the JsonException when a string can't be converted to an enum

### DIFF
--- a/ClassLibraries/Macross.Json.Extensions/Test/JsonStringEnumMemberConverterTests.cs
+++ b/ClassLibraries/Macross.Json.Extensions/Test/JsonStringEnumMemberConverterTests.cs
@@ -143,6 +143,54 @@ namespace Macross.Json.Extensions.Tests
 			JsonSerializer.Deserialize<EnumDefinition>(@"255", options);
 		}
 
+		[TestMethod]
+		public void EnumMemberInvalidDeserializationIncludesJsonPathInMessageTest()
+		{
+			JsonSerializerOptions options = new JsonSerializerOptions
+			{
+				Converters = { new JsonStringEnumMemberConverter() }
+			};
+
+			try
+			{
+				JsonSerializer.Deserialize<EnumDefinition>(@"""invalid_value""", options);
+				Assert.Fail($"A {nameof(JsonException)} is expected to be thrown.");
+			}
+			catch (JsonException jsonException)
+			{
+				StringAssert.Contains(jsonException.Message, ". Path: $");
+			}
+			catch (Exception exception)
+			{
+				Assert.Fail($"A {nameof(JsonException)} is expected to be thrown but a {exception.GetType().FullName} was thrown.");
+				throw;
+			}
+		}
+
+		[TestMethod]
+		public void EnumMemberFlagInvalidDeserializationIncludesJsonPathInMessageTest()
+		{
+			JsonSerializerOptions options = new JsonSerializerOptions
+			{
+				Converters = { new JsonStringEnumMemberConverter() }
+			};
+
+			try
+			{
+				JsonSerializer.Deserialize<FlagDefinitions>(@"""invalid_value""", options);
+				Assert.Fail($"A {nameof(JsonException)} is expected to be thrown.");
+			}
+			catch (JsonException jsonException)
+			{
+				StringAssert.Contains(jsonException.Message, ". Path: $");
+			}
+			catch (Exception exception)
+			{
+				Assert.Fail($"A {nameof(JsonException)} is expected to be thrown but a {exception.GetType().FullName} was thrown.");
+				throw;
+			}
+		}
+
 		[JsonConverter(typeof(JsonStringEnumMemberConverter))]
 		[Flags]
 		public enum FlagDefinitions


### PR DESCRIPTION
The JsonException exception thrown will now include the JSON path, line number and byte position of the string that can not be converted to an enum.