### PR TITLE
Bump system.text.json dependency to address CVE-2021-26701

### DIFF
--- a/ClassLibraries/Macross.Json.Extensions/Code/Macross.Json.Extensions.csproj
+++ b/ClassLibraries/Macross.Json.Extensions/Code/Macross.Json.Extensions.csproj
@@ -47,7 +47,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="4.7.0" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #23 

I just bumped system.text.json to version 4.7.2 which shouldn't be a breaking change. All the tests still pass. Would love to get this in so we can use this library.